### PR TITLE
Ensure declaration is added on distinct line re: PSR12

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,7 +22,7 @@ async function addStrictTypesDeclaration(document: vscode.TextDocument) {
 
     if (firstLine.includes('<?php')) {
         // Add declaration after PHP opening tag
-        edit.insert(document.uri, new vscode.Position(0, firstLine.length), ' declare(strict_types=1); ');
+        edit.insert(document.uri, new vscode.Position(0, firstLine.length), '\n\ndeclare(strict_types=1);');
     } else {
         // Add PHP tags and declaration
         edit.insert(document.uri, new vscode.Position(0, 0), '<?php declare(strict_types=1); ?>\n');


### PR DESCRIPTION
As per [this description](https://www.php-fig.org/psr/psr-12/#3-declare-statements-namespace-and-import-statements)

> The header of a PHP file may consist of a number of different blocks. If present, each of the blocks below MUST be separated by a single blank line...